### PR TITLE
WIP: Correct application development docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,6 +11,8 @@ _The below instructions have been tested on Ubuntu 20.04_
 ```bash
 sudo apt update
 sudo apt install \
+  appstream-util \
+  cmake \
   gettext \
   git \
   gir1.2-granite-1.0 \
@@ -18,23 +20,21 @@ sudo apt install \
   gstreamer1.0-plugins-bad \
   gstreamer1.0-plugins-good \
   gstreamer1.0-plugins-ugly \
+  libgirepository1.0-dev \
   libgstreamer1.0-0 \
   libgtk-3-dev \
   libgranite5 \
-  meson \
   pip \
   python-gi-cairo \
   python3-gst-1.0 \
   python3-venv
 
-sudo snap install libhandy
-```
-
-In case of problems with the `libhandy` installation, try this instead:
-
-```bash
+sudo add-apt-repository ppa:apandada1/libhandy-1
+sudo apt update
 sudo apt install libhandy-1-0 libhandy-1-dev
 ```
+
+In case of issues with the `libhandy` installation, please refer to our [GitHub build script](.github/workflows/build.yml) on an alternative source of the library packages.
 
 ### UI development
 
@@ -60,7 +60,12 @@ It is generally a good idea to set up a virtual environment to avoid referencing
 python3 -m venv venv
 source ./venv/bin/activate
 
+python -m pip install --upgrade pip
 pip install -r requirements.txt
+
+pip install \
+  meson \
+  ninja
 
 pip install \
   pytest \
@@ -69,29 +74,34 @@ pip install \
 
 ## Build and install
 
+### Configure
+
 Let's assume you wish to build the application under the `build/` directory and install the binaries under `app/`:
 
 ```bash
-meson build --prefix=app
+meson --prefix=$(pwd)/app ./build
+
 ninja -C build install
 ```
 
 ### Install translation files
 
 ```bash
-$ ninja -C build com.github.geigi.cozy-update-po
-$ ninja -C build extra-update-po
+ninja -C build com.github.geigi.cozy-update-po
+ninja -C build extra-update-po
 ```
 
 ## Run application
 
 ```bash
 XDG_DATA_DIRS=app/share:/usr/share \
-PYTHONPATH=app/lib/python3/dist-packages \
+PYTHONPATH=app/lib/python3.8/site-packages \
   app/bin/com.github.geigi.cozy
 ```
 
-Everytime you make code changes, you will need to run `ninja -C build install` before you run the application.
+Your Python path may be different so you might need to amend the `PYTHONPATH` environment variable above in case of errors.
+
+Please note, every time you make code changes, you need to execute `ninja -C build install` before you run the application.
 
 ## Test
 


### PR DESCRIPTION
This PR correct a few issues in the original development setup recipe.

- switched to a `pip` version of Meson as it plays better with Python virtual environments (it also makes it consistent with the [GitHub build script](.github/workflows/build.yml))
- Meson prefix has been corrected to be an absolute path
- corrected `libhandy` installation notes
- added missing dependencies
- opted for `ninja` installed with `pip` to avoid implicit dependencies on the version provided by the operating system and for consistency with the GitHub build script
- removed remaining `$` command prefixes for easier copy-and-paste